### PR TITLE
Enabled prune mode for Bitcoin package

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This package makes it easy to deploy a [bitcoin](https://bitcoin.org) node in a 
 - docker-compose
 
    Install [docker-compose](https://docs.docker.com/compose/install)
-   
+
 **Note**: Make sure you can run `git`, `docker ps`, `docker-compose` without any issue and without sudo command.
 
 
@@ -51,8 +51,10 @@ You can edit the `docker-compose.yml` and add extra options, such as:
 | BTC_RPCUSER | dappnode |
 | BTC_RPCPASSWORD | dappnode |
 | BTC_TXINDEX | 0 |
+| BTC_PRUNE | 0 |
 
-by default BTC_TXINDEX is 0, but the installation of the DAppNodePackage will set this value to 1, since it's a recommended value for other applications.
+by default BTC_TXINDEX is 0, but the installation of the DAppNodePackage will set this value to 1, since it's a recommended value for other applications. BTC_PRUNE is 0 by default. Enable blockchain prunning by setting it to a
+value larger than 550 (550Mb) , for example BTC_PRUNE=30000 to maintain only 30Gb of full blockchain data.
 ```
 
 ## License

--- a/build/bin/docker_entrypoint.sh
+++ b/build/bin/docker_entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+btc_prune=${BTC_PRUNE:-0}
+if [ $btc_prune -ne 0 ] ; then
+    BTC_TXINDEX=0
+fi
+
 BITCOIN_DIR=/root/.bitcoin
 BITCOIN_CONF=${BITCOIN_DIR}/bitcoin.conf
 
@@ -45,6 +50,7 @@ disablewallet=${BTC_DISABLEWALLET:-1}
 # Enable an on-disk txn index. Allows use of getrawtransaction for txns not in
 # mempool.
 txindex=${BTC_TXINDEX:-0}
+prune=${BTC_PRUNE:-0}
 testnet=${BTC_TESTNET:-0}
 dbcache=${BTC_DBCACHE:-512}
 zmqpubrawblock=${BTC_ZMQPUBRAWBLOCK:-tcp://0.0.0.0:28332}

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bitcoinprune.dnp.dappnode.eth",
+  "name": "bitcoin.dnp.dappnode.eth",
   "version": "0.1.0",
   "description": "The bitcoin daemon. Bitcoind is a program that implements the Bitcoin protocol for remote procedure call (RPC) use.",
   "avatar": "/ipfs/QmWwNmBfs5e9PogW2BMEnMoH1BLF3Yddde3EvgpF3s1toT",

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "bitcoinprune.dnp.dappnode.eth",
   "version": "0.1.0",
-  "description": "The bitcoin daemon configured with prune option. Bitcoind is a program that implements the Bitcoin protocol for remote procedure call (RPC) use.",
+  "description": "The bitcoin daemon. Bitcoind is a program that implements the Bitcoin protocol for remote procedure call (RPC) use.",
   "avatar": "/ipfs/QmWwNmBfs5e9PogW2BMEnMoH1BLF3Yddde3EvgpF3s1toT",
   "type": "service",
   "image": {
@@ -12,13 +12,13 @@
       "8333:8333"
     ],
     "volumes": [
-      "bitcoin_data:/root/.bitcoinprune"
+      "bitcoin_data:/root/.bitcoin"
     ],
     "environment": [
       "BTC_RPCUSER=dappnode",
       "BTC_RPCPASSWORD=dappnode",
-      "BTC_TXINDEX=0",
-      "BTC_PRUNE=550"
+      "BTC_TXINDEX=1",
+      "BTC_PRUNE=0"
     ]
   },
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
-  "name": "bitcoin.dnp.dappnode.eth",
+  "name": "bitcoinprune.dnp.dappnode.eth",
   "version": "0.1.0",
-  "description": "The bitcoin daemon. Bitcoind is a program that implements the Bitcoin protocol for remote procedure call (RPC) use.",
+  "description": "The bitcoin daemon configured with prune option. Bitcoind is a program that implements the Bitcoin protocol for remote procedure call (RPC) use.",
   "avatar": "/ipfs/QmWwNmBfs5e9PogW2BMEnMoH1BLF3Yddde3EvgpF3s1toT",
   "type": "service",
   "image": {
@@ -12,18 +12,20 @@
       "8333:8333"
     ],
     "volumes": [
-      "bitcoin_data:/root/.bitcoin"
+      "bitcoin_data:/root/.bitcoinprune"
     ],
     "environment": [
       "BTC_RPCUSER=dappnode",
       "BTC_RPCPASSWORD=dappnode",
-      "BTC_TXINDEX=1"
+      "BTC_TXINDEX=0",
+      "BTC_PRUNE=550"
     ]
   },
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",
   "contributors": [
     "Abel Boldú (@vdo)",
-    "Eduardo Antuña <eduadiez@gmail.com> (https://github.com/eduadiez)"
+    "Eduardo Antuña <eduadiez@gmail.com> (https://github.com/eduadiez)",
+    "Loco del Bitcoin <ellocodelbitcoin@gmail.com>"
   ],
   "keywords": [
     "bitcoin",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         environment:
             - "BTC_RPCUSER=dappnode"
             - "BTC_RPCPASSWORD=dappnode"
-            - "BTC_TXINDEX=1"
-            - "BTC_PRUNE=0"
+            - "BTC_TXINDEX=0"
+            - "BTC_PRUNE=550"
 volumes:
     bitcoin_data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         environment:
             - "BTC_RPCUSER=dappnode"
             - "BTC_RPCPASSWORD=dappnode"
-            - "BTC_TXINDEX=0"
-            - "BTC_PRUNE=550"
+            - "BTC_TXINDEX=1"
+            - "BTC_PRUNE=0"
 volumes:
     bitcoin_data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,6 @@ services:
             - "BTC_RPCUSER=dappnode"
             - "BTC_RPCPASSWORD=dappnode"
             - "BTC_TXINDEX=1"
+            - "BTC_PRUNE=0"
 volumes:
     bitcoin_data: {}


### PR DESCRIPTION
A new variable BTC_PRUNE is defined. It can have values 550 or above. This is the number of megabytes that the bitcoin blockchain will take.
Thought for those of us who want to have a pruned bitcoin
As this is incompatible with the txindex option , logic has been added to set txindex=0 when BTC_PRUNE has been set to any value different than 0