### PR TITLE
Add auto-check action

### DIFF
--- a/.github/workflows/auto-check.yml
+++ b/.github/workflows/auto-check.yml
@@ -1,0 +1,19 @@
+name: Bump upstream version
+
+on:
+  schedule:
+    - cron: "00 */4 * * *"
+  push:
+    branches:
+      - "master"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npx @dappnode/dappnodesdk github-action bump-upstream
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PINATA_API_KEY: ${{ secrets.PINATA_API_KEY }}
+          PINATA_SECRET_API_KEY: ${{ secrets.PINATA_SECRET_API_KEY }}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,9 +1,9 @@
 FROM debian:bullseye-slim as binary
 
-ARG VERSION=0.20.0
+ARG UPSTREAM_VERSION=0.20.0
 
-ENV FILENAME bitcoin-${VERSION}-x86_64-linux-gnu.tar.gz
-ENV DOWNLOAD_URL https://bitcoin.org/bin/bitcoin-core-${VERSION}/${FILENAME}
+ENV FILENAME bitcoin-${UPSTREAM_VERSION}-x86_64-linux-gnu.tar.gz
+ENV DOWNLOAD_URL https://bitcoin.org/bin/bitcoin-core-${UPSTREAM_VERSION}/${FILENAME}
 ENV SHA256SUM 35ec10f87b6bc1e44fd9cd1157e5dfa483eaf14d7d9a9c274774539e7824c427
 
 ADD $DOWNLOAD_URL /$FILENAME
@@ -13,7 +13,7 @@ RUN if [ x"$( sha256sum /${FILENAME} | awk '{print $1}' )" != x"${SHA256SUM}" ];
   exit 1; \
   else \
   tar xzvf /$FILENAME; \
-  mv /bitcoin-${VERSION} /bitcoin; \
+  mv /bitcoin-${UPSTREAM_VERSION} /bitcoin; \
   fi
 
 FROM debian:bullseye-slim AS final

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -12,6 +12,8 @@
     "Eduardo Antuña <eduadiez@gmail.com> (https://github.com/eduadiez)",
     "Loco del Bitcoin <ellocodelbitcoin@gmail.com>"
   ],
+  "upstreamRepo": "bitcoin/bitcoin",
+  "upstreamArg": "UPSTREAM_VERSION",
   "categories": ["Blockchain"],
   "keywords": ["bitcoin", "btc"],
   "links": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,15 @@
-version: '3.4'
+version: "3.4"
 services:
   bitcoin.dnp.dappnode.eth:
-    image: 'bitcoin.dnp.dappnode.eth:0.1.6'
-    build: ./build
+    build:
+      context: ./build
+      args:
+        UPSTREAM_VERSION: v0.20.0
+    image: "bitcoin.dnp.dappnode.eth:0.1.6"
     volumes:
-      - 'bitcoin_data:/root/.bitcoin'
+      - "bitcoin_data:/root/.bitcoin"
     ports:
-      - '8333:8333'
+      - "8333:8333"
     environment:
       - BTC_RPCUSER=dappnode
       - BTC_RPCPASSWORD=dappnode


### PR DESCRIPTION
The Github repo bitcoin/bitcoin publishes releases so we can use it as source for the auto-check action. However the Dockerfile needs work since UPSTREAM_REPO is prefixed with `v` (`v0.20.0`) while the Dockerfile expects just `0.20.0`.