### PR TITLE
Allow rpcallowip field to be configurable

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "bitcoin.dnp.dappnode.eth",
-  "version": "0.1.6",
-  "upstreamVersion": "v22.0",
+  "version": "0.2.0",
+  "upstreamVersion": "v23.0",
   "upstreamRepo": "bitcoin/bitcoin",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Support the Bitcoin network, run your own node",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - BTC_TXINDEX=1
       - BTC_PRUNE=0
       - BTC_DISABLEWALLET=1
+      - BTC_RPCALLOWIP=172.33.0.0/16
     restart: always
 volumes:
   bitcoin_data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: "3.4"
 services:
   bitcoin.dnp.dappnode.eth:
-    image: "bitcoin.dnp.dappnode.eth:0.1.6"
+    image: "bitcoin.dnp.dappnode.eth:0.2.0"
     build:
       context: ./build
       args:
-        UPSTREAM_VERSION: v22.0
+        UPSTREAM_VERSION: v23.0
     volumes:
       - "bitcoin_data:/root/.bitcoin"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.4"
 services:
   bitcoin.dnp.dappnode.eth:
-    image: "bitcoin.dnp.dappnode.eth:0.2.0"
+    image: "bitcoin.dnp.dappnode.eth:0.1.6"
     build:
       context: ./build
       args:


### PR DESCRIPTION
~~- 0.23 was recently released~~
- i have found it useful to allow connections from my local LAN when my dappnode-wifi or vpn isn't working reliably. The env var was already set up for use in the entrypoint script, it just needed to be exposed in the UI