### PR TITLE
Port standardization

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - "bitcoin_data:/root/.bitcoin"
     ports:
-      - "8333:8333"
+      - "8340:8340"
     environment:
       - BTC_RPCUSER=dappnode
       - BTC_RPCPASSWORD=dappnode
@@ -17,6 +17,7 @@ services:
       - BTC_PRUNE=0
       - BTC_DISABLEWALLET=1
       - BTC_RPCALLOWIP=172.33.0.0/16
+      - P2P_PORT=8340
     restart: always
 volumes:
   bitcoin_data: {}

--- a/src/docker_entrypoint.sh
+++ b/src/docker_entrypoint.sh
@@ -64,7 +64,7 @@ EOF
 #fi
 
 if [ $# -eq 0 ]; then
-    exec bitcoind -datadir=${BITCOIN_DIR} -conf=${BITCOIN_CONF}
+    exec bitcoind -datadir=${BITCOIN_DIR} -conf=${BITCOIN_CONF} -port={P2P_PORT}
 else
     exec "$@"
 fi


### PR DESCRIPTION
According to this issue https://github.com/dappnode/DAppNode/issues/457
We are selecting the host port for the client. 
 
 This is the flag which we have added to modify the p2p port
 ```
 -port=<port>
       Listen for connections on <port>. Nodes not using the default ports
       (default: 8333, testnet: 18333, signet: 38333, regtest: 18444)
       are unlikely to get incoming connections. Not relevant for I2P
       (see doc/i2p.md).
```