### PR TITLE
add rpcport as env

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You can edit the `docker-compose.yml` and add extra options, such as:
 | ---- | ------- |
 | BTC_RPCUSER | dappnode |
 | BTC_RPCPASSWORD | dappnode |
+| BTC_RPCPORT | 8332 |
 | BTC_TXINDEX | 0 |
 | BTC_PRUNE | 0 |
 | BTC_DISABLEWALLET | 1 |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     environment:
       - BTC_RPCUSER=dappnode
       - BTC_RPCPASSWORD=dappnode
+      - BTC_RPCPORT=8332
       - BTC_TXINDEX=1
       - BTC_PRUNE=0
       - BTC_DISABLEWALLET=1


### PR DESCRIPTION
Dappmanager needs RPCPORT to be an env variable in bitcoin package in order to ask its syncing status:
https://github.com/dappnode/DNP_DAPPMANAGER/blob/develop/packages/chains/src/drivers/bitcoin.ts#L121

This change also lets user customize the RPC port of its bitcoin dnp.