### PR TITLE
chore(deps): bump bitcoin to 30.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "bitcoin.dnp.dappnode.eth",
   "version": "0.1.10",
-  "upstreamVersion": "v30.0",
+  "upstreamVersion": "v30.2",
   "upstreamRepo": "bitcoin/bitcoin",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Support the Bitcoin network, run your own node",

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "bitcoin.dnp.dappnode.eth",
   "version": "0.1.10",
-  "upstreamVersion": "v26.2",
+  "upstreamVersion": "v30.0",
   "upstreamRepo": "bitcoin/bitcoin",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Support the Bitcoin network, run your own node",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ./src
       args:
-        UPSTREAM_VERSION: v26.2
+        UPSTREAM_VERSION: v30.0
     volumes:
       - bitcoin_data:/root/.bitcoin
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ./src
       args:
-        UPSTREAM_VERSION: v30.0
+        UPSTREAM_VERSION: v30.2
     volumes:
       - bitcoin_data:/root/.bitcoin
     ports:


### PR DESCRIPTION
Bumps Bitcoin Core to version 30.2. Arguments below.

Bitcoin version 30 is already the most popular version in the Bitcoin network. See [Clark Moody's Dashboard](https://bitcoin.clarkmoody.com/dashboard/):

<img width="668" height="752" alt="CleanShot 2025-12-20 at 12 02 12@2x" src="https://github.com/user-attachments/assets/3e9cb941-b333-48bb-a755-9fc2be12518f" />

Also according to [Bitcoin Core End of Life Policy](https://bitcoincore.org/en/lifecycle/), Bitcoin Core developers will "maintain the major versions until their 'Maintenance End'"
which happens on to be support for two last major versions as stated in "we generally maintain the current and previous major release".

Hence the current version is not only outdated but INSECURE.
And the proposed version in #50 (29.0) is also vulnerable because it is behind at least 2 bug fix releases in 29.x because the latest version is 29.2.
Also next major release (31) will make 29.x end of life.