### PR TITLE
ci: use dappnode-build-hash reusable workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,12 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    paths-ignore: ["README.md"]
+
+jobs:
+  build:
+    uses: dappnode/workflows/.github/workflows/dappnode-build-hash.yml@master
+    secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
       - name: Publish

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,29 +1,23 @@
 name: "Main"
 on:
-  pull_request:
   push:
     branches:
-      - "main"
       - "master"
       - "v[0-9]+.[0-9]+.[0-9]+"
     paths-ignore:
       - "README.md"
+  workflow_dispatch:
 
 jobs:
-  build-test:
-    runs-on: ubuntu-latest
-    name: Build test
-    if: github.event_name != 'push'
-    steps:
-      - uses: actions/checkout@v6
-      - run: npx @dappnode/dappnodesdk build --skip_save
-
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
       - name: Publish
         run: npx @dappnode/dappnodesdk publish patch --dappnode_team_preset
         env:


### PR DESCRIPTION
## Context

This repo's build pipeline (either an inlined `build-test` step with `--skip_save` or an inlined `npx dappnodesdk github-action build` call) is now consolidated into a thin caller for the new `dappnode/workflows/.github/workflows/dappnode-build-hash.yml@master` reusable workflow. This produces a properly tagged IPFS hash comment on every push to a non-default branch and on every PR.

## Approach

- `.github/workflows/build.yml` — thin stub calling `dappnode-build-hash` with `secrets: inherit`.
- `.github/workflows/main.yml` — slimmed to the release job only. `build-test` removed; `actions/checkout` upgraded to v7; Node 24 added.
- The `pull_request` trigger is moved from `main.yml` to `build.yml` (the new reusable workflow handles both events).

## Test instructions

1. Open a test PR or push to a feature branch.
2. Verify the `Build` workflow runs and posts a comment with an IPFS install link and hash tagged `(by dappnodebot/build-action)`.
3. After merge to the default branch, the `Main` workflow should run the release.