### PR TITLE
ci: skip build.yml on default branch pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build
 on:
   workflow_dispatch:
   push:
+    branches-ignore:
+      - "master"
     paths-ignore: ["README.md"]
 
 jobs:


### PR DESCRIPTION
## Context

`build.yml` triggers on `push` and `workflow_dispatch`. The reusable `dappnode-build-hash.yml` SDK already auto-detects pushes to the default branch and runs a no-op test build (no IPFS pin, no comment), so the workflow run is wasted CI on every merge.

## Approach

Add `branches-ignore: ["master"]` to the push trigger so the workflow doesn't even start on default-branch pushes. `workflow_dispatch` and pushes to other branches (e.g. tropibot bump branches) still trigger it as before.